### PR TITLE
feat(redux): implement rx ofType operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,15 +3,9 @@
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
 <a name="0.1.0"></a>
-# 0.1.0 (2018-08-13)
 
+# 0.1.0 (2018-08-13)
 
 ### Features
 
-* **redux:** implement createAction with type helpers ([cbede4f](https://www.github.com/Hotell/rex-tils/commit/cbede4f))
-
-
-
-# Change Log
-
-All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+- **redux:** implement createAction with type helpers ([cbede4f](https://www.github.com/Hotell/rex-tils/commit/cbede4f))

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "rollup-plugin-sourcemaps": "0.4.2",
     "rollup-plugin-terser": "1.0.1",
     "rollup-plugin-uglify": "4.0.0",
+    "rxjs": "6.2.2",
     "shx": "0.3.2",
     "sort-object-keys": "1.1.2",
     "standard-version": "4.4.0",

--- a/src/__tests__/redux/rx-operators.spec.ts
+++ b/src/__tests__/redux/rx-operators.spec.ts
@@ -1,7 +1,6 @@
 import { Subject } from 'rxjs'
 import { ActionsUnion, createAction } from '../../redux'
 import { ofType } from '../../redux/rx-operators'
-import { Action } from '../../redux/types'
 
 describe(`Rx operators`, () => {
   // it(`should properly filter action types via ofType`, () => {
@@ -26,8 +25,8 @@ describe(`Rx operators`, () => {
       const lulz = [] as object[]
       const haha = [] as object[]
 
-      actions.pipe(ofType(SET_AGE)).subscribe(x => lulz.push(x))
-      actions.pipe(ofType(SET_NAME)).subscribe(x => haha.push(x))
+      actions.pipe(ofType(SET_AGE)).subscribe((x) => lulz.push(x))
+      actions.pipe(ofType(SET_NAME)).subscribe((x) => haha.push(x))
 
       actions.next({ type: SET_AGE, payload: 33 })
 
@@ -56,8 +55,8 @@ describe(`Rx operators`, () => {
       const lulz = [] as object[]
       const haha = [] as object[]
 
-      actions.pipe(ofType(SET_AGE, SET_NAME)).subscribe(x => lulz.push(x))
-      actions.pipe(ofType(RELOAD_URL)).subscribe(x => haha.push(x))
+      actions.pipe(ofType(SET_AGE, SET_NAME)).subscribe((x) => lulz.push(x))
+      actions.pipe(ofType(RELOAD_URL)).subscribe((x) => haha.push(x))
 
       actions.next({ type: SET_AGE, payload: 33 })
 

--- a/src/__tests__/redux/rx-operators.spec.ts
+++ b/src/__tests__/redux/rx-operators.spec.ts
@@ -1,0 +1,84 @@
+import { Subject } from 'rxjs'
+import { ActionsUnion, createAction } from '../../redux'
+import { ofType } from '../../redux/rx-operators'
+import { Action } from '../../redux/types'
+
+describe(`Rx operators`, () => {
+  // it(`should properly filter action types via ofType`, () => {
+  //   expect(true).toBe(true)
+  // })
+
+  describe('ofType', () => {
+    const SET_AGE = '[core] set age'
+    const SET_NAME = '[core] set name'
+    const RELOAD_URL = '[router] Reload Page'
+
+    const Actions = {
+      setAge: (age: number) => createAction(SET_AGE, age),
+      setName: (name: string) => createAction(SET_NAME, name),
+      reloadUrl: () => createAction(RELOAD_URL),
+    }
+
+    type Actions = ActionsUnion<typeof Actions>
+
+    it('should filter by action type', () => {
+      const actions = new Subject<Actions>()
+      const lulz = [] as object[]
+      const haha = [] as object[]
+
+      actions.pipe(ofType(SET_AGE)).subscribe(x => lulz.push(x))
+      actions.pipe(ofType(SET_NAME)).subscribe(x => haha.push(x))
+
+      actions.next({ type: SET_AGE, payload: 33 })
+
+      expect(lulz).toEqual([{ type: SET_AGE, payload: 33 }])
+      expect(haha).toEqual([])
+
+      actions.next({ type: SET_AGE, payload: 11 })
+
+      expect(lulz).toEqual([
+        { type: SET_AGE, payload: 33 },
+        { type: SET_AGE, payload: 11 },
+      ])
+      expect(haha).toEqual([])
+
+      actions.next({ type: SET_NAME, payload: 'Martin' })
+
+      expect(lulz).toEqual([
+        { type: SET_AGE, payload: 33 },
+        { type: SET_AGE, payload: 11 },
+      ])
+      expect(haha).toEqual([{ type: SET_NAME, payload: 'Martin' }])
+    })
+
+    it('should filter by multiple action types', () => {
+      const actions = new Subject<Actions>()
+      const lulz = [] as object[]
+      const haha = [] as object[]
+
+      actions.pipe(ofType(SET_AGE, SET_NAME)).subscribe(x => lulz.push(x))
+      actions.pipe(ofType(RELOAD_URL)).subscribe(x => haha.push(x))
+
+      actions.next({ type: SET_AGE, payload: 33 })
+
+      expect(lulz).toEqual([{ type: SET_AGE, payload: 33 }])
+      expect(haha).toEqual([])
+
+      actions.next({ type: SET_NAME, payload: 'Martin' })
+
+      expect(lulz).toEqual([
+        { type: SET_AGE, payload: 33 },
+        { type: SET_NAME, payload: 'Martin' },
+      ])
+      expect(haha).toEqual([])
+
+      actions.next({ type: RELOAD_URL })
+
+      expect(lulz).toEqual([
+        { type: SET_AGE, payload: 33 },
+        { type: SET_NAME, payload: 'Martin' },
+      ])
+      expect(haha).toEqual([{ type: RELOAD_URL }])
+    })
+  })
+})

--- a/src/redux/rx-operators.ts
+++ b/src/redux/rx-operators.ts
@@ -1,0 +1,49 @@
+import { Observable, OperatorFunction } from 'rxjs'
+import { filter } from 'rxjs/operators'
+
+import { Action, ActionsOfType } from './types'
+
+export function ofType<V, T1 extends string>(
+  t1: T1
+): OperatorFunction<V, ActionsOfType<V, T1>>
+export function ofType<V, T1 extends string, T2 extends string>(
+  t1: T1,
+  t2: T2
+): OperatorFunction<V, ActionsOfType<V, T1 | T2>>
+export function ofType<
+  V,
+  T1 extends string,
+  T2 extends string,
+  T3 extends string
+>(t1: T1, t2: T2, t3: T3): OperatorFunction<V, ActionsOfType<V, T1 | T2 | T3>>
+export function ofType<
+  V,
+  T1 extends string,
+  T2 extends string,
+  T3 extends string,
+  T4 extends string
+>(
+  t1: T1,
+  t2: T2,
+  t3: T3,
+  t4: T4
+): OperatorFunction<V, ActionsOfType<V, T1 | T2 | T3 | T4>>
+export function ofType<
+  V,
+  T1 extends string,
+  T2 extends string,
+  T3 extends string,
+  T4 extends string,
+  T5 extends string
+>(
+  t1: T1,
+  t2: T2,
+  t3: T3,
+  t4: T4,
+  t5: T5
+): OperatorFunction<V, ActionsOfType<V, T1 | T2 | T3 | T4 | T5>>
+
+export function ofType(...keys: string[]) {
+  return (source: Observable<Action>) =>
+    source.pipe(filter(action => keys.indexOf(action.type) !== -1))
+}

--- a/src/redux/rx-operators.ts
+++ b/src/redux/rx-operators.ts
@@ -45,5 +45,5 @@ export function ofType<
 
 export function ofType(...keys: string[]) {
   return (source: Observable<Action>) =>
-    source.pipe(filter(action => keys.indexOf(action.type) !== -1))
+    source.pipe(filter((action) => keys.indexOf(action.type) !== -1))
 }

--- a/src/redux/types.ts
+++ b/src/redux/types.ts
@@ -12,7 +12,7 @@ import { AnyFunction, StringMap } from '../types'
 // }
 
 // We use conditional types so we can have only one type for defining Action
-export type Action<T extends string, P = void> = P extends void
+export type Action<T extends string = string, P = void> = P extends void
   ? { type: T }
   : { type: T; payload: P }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5103,6 +5103,12 @@ rx@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/rx/-/rx-4.1.0.tgz#a5f13ff79ef3b740fe30aa803fb09f98805d4782"
 
+rxjs@6.2.2:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.2.2.tgz#eb75fa3c186ff5289907d06483a77884586e1cf9"
+  dependencies:
+    tslib "^1.9.0"
+
 rxjs@^6.1.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.2.0.tgz#e024d0e180b72756a83c2aaea8f25423751ba978"


### PR DESCRIPTION
_If there is a linked issue, mention it here._

- [ ] Bug
- [x] Feature

## Requirements

- [x] Read the [contribution guidelines](./.github/CONTRIBUTING.md).
- [x] Wrote tests.
- [ ] Updated docs and upgrade instructions, if necessary.

## Rationale

To cover all parts of redux we need to have proper rx `ofType`  operator that understands `createAction` types. This PR implements it.

## Tasks

- [ ] Add docs
- [ ] Add examples