### PR TITLE
feat(redux): make actions readonly on both type and runtime level

### DIFF
--- a/src/__tests__/redux/actions.spec.ts
+++ b/src/__tests__/redux/actions.spec.ts
@@ -1,8 +1,20 @@
+jest.mock('../../environment', () => ({ IS_DEV: true, IS_PROD: false }))
+
 import { ActionsUnion, createAction } from '../../redux'
 
 // tslint:disable:no-magic-numbers
 
 describe(`Redux type-safe action helpers`, () => {
+  describe(`Should create immutable objects`, () => {
+    const SET_AGE = '[core] set age'
+    const setAge = (age: number) => createAction(SET_AGE, age)
+    const setAgeAction = setAge(33)
+
+    // @ts-ignore
+    expect(() => (setAgeAction.type = 'Foo')).toThrow()
+    // @ts-ignore
+    expect(() => (setAgeAction.payload = 44)).toThrow()
+  })
   describe(`Should work with constants`, () => {
     const SET_AGE = '[core] set age'
     const SET_NAME = '[core] set name'

--- a/src/redux/actions.ts
+++ b/src/redux/actions.ts
@@ -1,3 +1,4 @@
+import { IS_DEV } from '../environment'
 import { Action } from './types'
 
 export function createAction<T extends string>(type: T): Action<T>
@@ -6,5 +7,7 @@ export function createAction<T extends string, P>(
   payload: P
 ): Action<T, P>
 export function createAction<T extends string, P>(type: T, payload?: P) {
-  return payload === undefined ? { type } : { type, payload }
+  const action = payload === undefined ? { type } : { type, payload }
+
+  return IS_DEV ? Object.freeze(action) : action
 }

--- a/src/redux/types.ts
+++ b/src/redux/types.ts
@@ -13,8 +13,8 @@ import { AnyFunction, StringMap } from '../types'
 
 // We use conditional types so we can have only one type for defining Action
 export type Action<T extends string = string, P = void> = P extends void
-  ? { type: T }
-  : { type: T; payload: P }
+  ? Readonly<{ type: T }>
+  : Readonly<{ type: T; payload: P }>
 
 export type ActionsUnion<A extends StringMap<AnyFunction>> = ReturnType<
   A[keyof A]


### PR DESCRIPTION
_If there is a linked issue, mention it here._

- [ ] Bug
- [x] Feature

## Requirements

- [x] Read the [contribution guidelines](./.github/CONTRIBUTING.md).
- [x] Wrote tests.
- [x] Updated docs and upgrade instructions, if necessary.

## Rationale

It's good to make action objects immutable during dev. This PR makes objects frozen on dev on runtime and readonly in compile time on both prod and dev