### PR TITLE
fix(build): don't bundle rx deps. mark it as optionalDeps

### DIFF
--- a/config/rollup.config.js
+++ b/config/rollup.config.js
@@ -43,7 +43,11 @@ const PATHS = {
 /**
  * @type {string[]}
  */
-const external = Object.keys(pkg.peerDependencies) || []
+const external = [
+  ...Object.keys(pkg.peerDependencies || {}),
+  ...Object.keys(pkg.optionalDependencies || {}),
+  'rxjs/operators',
+]
 
 /**
  *  @type {Plugin[]}

--- a/package.json
+++ b/package.json
@@ -74,6 +74,9 @@
   "peerDependencies": {
     "tslib": ">=1.9.0"
   },
+  "optionalDependencies": {
+    "rxjs": "^6.2.2"
+  },
   "dependencies": {},
   "devDependencies": {
     "@types/chokidar": "1.7.5",


### PR DESCRIPTION
_If there is a linked issue, mention it here._

- [x] Bug
- [ ] Feature

## Requirements

- [x] Read the [contribution guidelines](./.github/CONTRIBUTING.md).
- [ ] Wrote tests.
- [ ] Updated docs and upgrade instructions, if necessary.

## Rationale

Rx was bundled during build process. This  fixes this and also adds rx as opitonalDeps