### PR TITLE
feat(react): add pickWithRest for handling generic ...rest

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,26 @@ rex-tils API is tiny and consist of 2 categories:
 
 - use within Epic/Effect for filtering actions
 
+**`pickWithRest<Props, PickedProps>( props: object, pickProps: keyof PickedProps[] )`**
+
+- use for getting generic ...rest from object ( TS cannot do that by default )
+- you need to explicitly state generic params
+- `Props` generic props intersection
+- `PickedProps` props type from which you wanna pick properties so you get them via destructuring
+
+```tsx
+type InjectedProps = { one: number; two: boolean }
+function test<OriginalProps>(props: OriginalProps) {
+  type Props = OriginalProps & InjectedProps
+  const {
+    // $ExpectType number
+    one,
+    // $ExpectType OriginalProps
+    rest,
+  } = pickWithRest<Props, InjectedProps>(props, ['one'])
+}
+```
+
 ### 2. Compile time TypeScript type helpers
 
 **`ActionsUnion<A extends StringMap<AnyFunction>> = ReturnType<A[keyof A]>`**

--- a/package.json
+++ b/package.json
@@ -75,8 +75,8 @@
     "tslib": ">=1.9.0"
   },
   "optionalDependencies": {
-    "rxjs": "^6.2.2",
-    "react": "^16.4.2"
+    "react": "^16.4.2",
+    "rxjs": "^6.2.2"
   },
   "dependencies": {},
   "devDependencies": {
@@ -86,6 +86,7 @@
     "@types/node": "10.7.0",
     "@types/prettier": "1.13.2",
     "@types/react": "16.4.10",
+    "@types/react-dom": "16.0.7",
     "@types/webpack-config-utils": "2.3.0",
     "awesome-typescript-loader": "5.2.0",
     "commitizen": "2.10.1",
@@ -99,6 +100,7 @@
     "lint-staged": "7.2.2",
     "prettier": "1.14.2",
     "react": "16.4.2",
+    "react-dom": "16.4.2",
     "rollup": "0.64.1",
     "rollup-plugin-commonjs": "9.1.5",
     "rollup-plugin-json": "3.0.0",

--- a/src/__tests__/react/generic-rest.spec.ts
+++ b/src/__tests__/react/generic-rest.spec.ts
@@ -1,0 +1,79 @@
+import {
+  Component,
+  ComponentClass,
+  ComponentType,
+  createElement,
+  Fragment,
+} from 'react'
+import { render, unmountComponentAtNode } from 'react-dom'
+
+import { pickWithRest } from '../../react'
+import { Omit } from '../../types'
+
+describe(`generic typesafe rest`, () => {
+  it(`should return rest and picked props with proper types when HoC is defined`, () => {
+    type InjectedProps = { enableLog: boolean }
+    type Config = { type: 'log' | 'warn' | 'error' }
+
+    const withLog = (config: Config) => <
+      OriginalProps extends Partial<InjectedProps>
+    >(
+      WrappedComponent: ComponentType<OriginalProps>
+    ) => {
+      type Props = OriginalProps & InjectedProps
+      type HoCProps = Omit<Props, InjectedProps> & Partial<InjectedProps>
+
+      return (class WithLog extends Component<Props> {
+        render() {
+          const { enableLog = true, rest } = pickWithRest<Props, InjectedProps>(
+            this.props,
+            ['enableLog']
+          )
+
+          try {
+            expect(() => {
+              // tslint:disable-next-line:no-shadowed-variable
+              const { enableLog, rest } = pickWithRest<Props, InjectedProps>(
+                this.props,
+                // @ts-ignore
+                ['enableLogzzz']
+              )
+              console.log(enableLog, rest)
+            }).toThrow()
+            // tslint:disable-next-line:no-empty
+          } catch {}
+
+          console[config.type]('render called')
+
+          return createElement(WrappedComponent, {
+            enableLog,
+            ...(rest as object),
+          } as Props)
+        }
+      } as any) as ComponentClass<HoCProps>
+    }
+
+    class TestComponent extends Component<{} & InjectedProps> {
+      render() {
+        return this.props.enableLog ? 'log enabled' : 'log disabled'
+      }
+    }
+
+    const EnhancedTestComponent = withLog({ type: 'log' })(TestComponent)
+
+    const App = () =>
+      createElement(Fragment, {}, [
+        createElement(TestComponent, { key: '1', enableLog: false }),
+        createElement('hr', { key: '2' }),
+        createElement(EnhancedTestComponent, { key: '3' }),
+      ])
+
+    const mountTo = document.createElement('div')
+    render(createElement(App), mountTo)
+
+    expect(mountTo.textContent).toContain('log enabled')
+    expect(mountTo.textContent).toContain('log disabled')
+
+    unmountComponentAtNode(mountTo)
+  })
+})

--- a/src/react/generic-rest.ts
+++ b/src/react/generic-rest.ts
@@ -1,0 +1,44 @@
+import { __rest } from 'tslib'
+import { Omit } from '../types'
+
+/**
+ * Use this to get properly typed {...rest} when used with generics. ( React HoC )
+ *
+ * @example
+ * ```tsx
+ * type InjectedProps = { enableLog: boolean }
+ * type Config = {...}
+ *
+ * const withLog = (config: Config) => <OriginalProps extends InjectedProps>(WrappedComponent: ComponentType<OriginalProps>) => {
+ *
+ *   type Props = OriginalProps & InjectedProps
+ *
+ *   return class WithLog extends Component<Props> {
+ *     render(){
+ *       const {enableLog, rest} = genRest<Props, InjectedProps>(this.props, ['enableLog'])
+ *       return <WrappedComponent log={enableLog} {...rest} />
+ *     }
+ *   }
+ * }
+ * ```
+ *
+ * @param props
+ * @param pickProps
+ */
+export const pickWithRest = <
+  Props extends object = object,
+  PickedProps extends object = object,
+  Rest = { rest: Omit<Props, PickedProps> }
+>(
+  props = {} as object,
+  pickProps = [] as (keyof PickedProps)[]
+) => {
+  const rest = __rest(props, pickProps as string[])
+  const picked = pickProps.reduce(
+    // @ts-ignore
+    (acc, nextPropName) => ({ ...acc, [nextPropName]: props[nextPropName] }),
+    {}
+  )
+
+  return { ...picked, rest } as PickedProps & Rest
+}

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -1,1 +1,2 @@
 export * from './types'
+export * from './generic-rest'

--- a/yarn.lock
+++ b/yarn.lock
@@ -111,6 +111,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-dom@16.0.7":
+  version "16.0.7"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.0.7.tgz#54d0f867a76b90597e8432030d297982f25c20ba"
+  dependencies:
+    "@types/node" "*"
+    "@types/react" "*"
+
 "@types/react@*", "@types/react@16.4.10":
   version "16.4.10"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.4.10.tgz#fb577091034b25a81f829923e7d38258f43e3165"
@@ -4527,7 +4534,16 @@ rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react@16.4.2:
+react-dom@16.4.2:
+  version "16.4.2"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.4.2.tgz#4afed569689f2c561d2b8da0b819669c38a0bda4"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
+
+react@^16.4.2:
   version "16.4.2"
   resolved "https://registry.yarnpkg.com/react/-/react-16.4.2.tgz#2cd90154e3a9d9dd8da2991149fdca3c260e129f"
   dependencies:


### PR DESCRIPTION
_If there is a linked issue, mention it here._

- [ ] Bug
- [x] Feature

## Requirements

- [x] Read the [contribution guidelines](./.github/CONTRIBUTING.md).
- [x] Wrote tests.
- [x] Updated docs and upgrade instructions, if necessary.

## Rationale

Currently you cannot use spread on destructuring with generics in TS. This helper method allows that in type safe way

https://github.com/Microsoft/TypeScript/issues/15792
https://github.com/Microsoft/TypeScript/issues/10727