### PR TITLE
feat(react): implement defaultProps helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ rex-tils API is tiny and consist of 2 categories:
 
 - use within Epic/Effect for filtering actions
 
+#### React/Preact related helpers:
+
 **`pickWithRest<Props, PickedProps>( props: object, pickProps: keyof PickedProps[] )`**
 
 - use for getting generic ...rest from object ( TS cannot do that by default )
@@ -152,6 +154,55 @@ function test<OriginalProps>(props: OriginalProps) {
     // $ExpectType OriginalProps
     rest,
   } = pickWithRest<Props, InjectedProps>(props, ['one'])
+}
+```
+
+**`DefaultProps<T>(props: T): Readonly<T>`**
+
+- returns frozen object ( useful for default props )
+
+**`createPropsGetter<T>(props: T): T`**
+
+> **Why ?**
+>
+> https://medium.com/@martin_hotell/react-typescript-and-defaultprops-dilemma-ca7f81c661c7
+
+- use for resolving defaultProps within component implementation
+- goes side by side with `DefaultProps` helper/type alias
+- it's just identity function with proper props type resolution
+
+```tsx
+type Props = {
+  onClick: (e: MouseEvent<HTMLElement>) => void
+  children: ReactNode
+} & DefaultProps<typeof defaultProps>
+
+const defaultProps = DefaultProps({
+  color: 'blue' as 'blue' | 'green' | 'red',
+  type: 'button' as 'button' | 'submit',
+})
+const getProps = createPropsGetter(defaultProps)
+
+class Button extends Component<Props> {
+  static readonly defaultProps = defaultProps
+  render() {
+    const {
+      // $ExpectType (e: MouseEvent<HTMLElement>) => void
+      onClick: handleClick,
+      // $ExpectType 'blue' | 'green' | 'red'
+      color,
+      // $ExpectType 'button' | 'submit'
+      type,
+      // $ExpectType ReactNode
+      children,
+    } = getProps(this.props)
+
+    return (
+      <button onClick={handleClick} type={type} className={color}>
+        {children}
+      </button>
+    )
+  }
 }
 ```
 
@@ -268,6 +319,11 @@ type PropsFromComponent = GetComponentPropsAndState<Test>
 // $ExpectType {props: {who: string}, state: {count: number}}
 type PropsAndStateFromComponent = GetComponentPropsAndState<TestWithState>
 ```
+
+**`DefaultProps<T>(props: T): Partial<T>`**
+
+- type alias
+- useful for declaring Component props intersection with defaultProps
 
 ## Guides
 

--- a/src/__tests__/react/default-props.spec.ts
+++ b/src/__tests__/react/default-props.spec.ts
@@ -1,0 +1,105 @@
+import { Component, createElement, MouseEvent, ReactNode, SFC } from 'react'
+import { render, unmountComponentAtNode } from 'react-dom'
+
+import { createPropsGetter, DefaultProps } from '../../react'
+
+// tslint:disable:no-magic-numbers
+
+describe(`default props helper`, () => {
+  type Props = {
+    onClick: (e: MouseEvent<HTMLElement>) => void
+    children: ReactNode
+  } & DefaultProps<typeof defaultProps>
+
+  const defaultProps = DefaultProps({
+    color: 'blue' as 'blue' | 'green' | 'red',
+    type: 'button' as 'button' | 'submit',
+  })
+  const getProps = createPropsGetter(defaultProps)
+
+  const resolveColorTheme = (color: NonNullable<Props['color']>) => {
+    const btnThemes = {
+      blue: 'btn-primary',
+      green: 'btn-secondary',
+      red: 'btn-accent',
+    }
+
+    return btnThemes[color] || 'btn-default'
+  }
+
+  it(`should properly resolve default props`, () => {
+    class Button extends Component<Props> {
+      static readonly defaultProps = defaultProps
+      render() {
+        const {
+          // $ExpectType (e: MouseEvent<HTMLElement>) => void
+          onClick: handleClick,
+          // $ExpectType 'blue' | 'green' | 'red'
+          color,
+          // $ExpectType 'button' | 'submit'
+          type,
+          // $ExpectType ReactNode
+          children,
+        } = getProps(this.props)
+
+        const cssClass = resolveColorTheme(color)
+
+        return createElement(
+          'button',
+          { type, className: cssClass, onClick: handleClick },
+          children
+        )
+      }
+    }
+
+    const ButtonSFC: SFC<Props> = (props) => {
+      const {
+        // $ExpectType (e: MouseEvent<HTMLElement>) => void
+        onClick: handleClick,
+        // $ExpectType 'blue' | 'green' | 'red'
+        color,
+        // $ExpectType 'button' | 'submit'
+        type,
+        // $ExpectType ReactNode
+        children,
+      } = getProps(props)
+
+      const cssClass = resolveColorTheme(color)
+
+      return createElement(
+        'button',
+        { type, className: cssClass, onClick: handleClick },
+        children
+      )
+    }
+    ButtonSFC.defaultProps = defaultProps
+
+    const mountTo = document.createElement('div')
+
+    class App extends Component {
+      private handleClick = () => {
+        console.log('clicked!')
+      }
+      render() {
+        return createElement(
+          'div',
+          {},
+          createElement(Button, {
+            onClick: this.handleClick,
+            children: 'Click me!',
+          }),
+          createElement(ButtonSFC, {
+            onClick: this.handleClick,
+            children: 'Click me!',
+          })
+        )
+      }
+    }
+
+    render(createElement(App), mountTo)
+
+    expect(mountTo.querySelectorAll('button')).toHaveLength(2)
+
+    unmountComponentAtNode(mountTo)
+  })
+})

--- a/src/react/default-props.ts
+++ b/src/react/default-props.ts
@@ -1,0 +1,29 @@
+import { Omit } from '../types'
+
+/**
+ * @private
+ */
+type GetDefaultProps<
+  P extends object,
+  DP extends Partial<P> = Partial<P>
+> = DP & Omit<P, DP>
+
+/**
+ * identity function helper to properly resolve default and required props type annotation within Component
+ * @param _defaultProps
+ */
+export const createPropsGetter = <DP extends Readonly<object>>(
+  _defaultProps: DP
+) => <P extends Partial<DP>>(props: P): GetDefaultProps<P, DP> => props as any
+
+/**
+ * helper to create Readonly default props
+ * @param props
+ */
+export const DefaultProps = <T extends object>(props: T) => Object.freeze(props)
+
+/**
+ * type alias to define defaultProps within Props intersection
+ * @param props
+ */
+export type DefaultProps<T extends Readonly<object>> = Partial<T>

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -1,2 +1,3 @@
 export * from './types'
 export * from './generic-rest'
+export * from './default-props'

--- a/tslint.json
+++ b/tslint.json
@@ -61,7 +61,6 @@
     "prefer-for-of": true,
     "match-default-export-name": true,
     "prefer-const": true,
-    "prefer-method-signature": true,
     "ban-types": [
       true,
       [


### PR DESCRIPTION
_If there is a linked issue, mention it here._

- [ ] Bug
- [x] Feature

## Requirements

- [x] Read the [contribution guidelines](./.github/CONTRIBUTING.md).
- [x] Wrote tests.
- [x] Updated docs and upgrade instructions, if necessary.

## Rationale

function helpers and type alias to properly handle default props till TS 3.0 will be applied within react types