### PR TITLE
fix(type-guards): fix isNumber return type

### DIFF
--- a/src/__tests__/guards/type-guards.spec.ts
+++ b/src/__tests__/guards/type-guards.spec.ts
@@ -93,6 +93,18 @@ describe(`type guards`, () => {
       expect(isNumber(Infinity)).toBe(true)
       expect(isNumber(-1)).toBe(true)
       expect(isNumber('123')).toBe(false)
+
+      // tslint:disable-next-line:prefer-const
+      let narrowValue = 123 as number | { foo: () => {} }
+
+      if (isNumber(narrowValue)) {
+        // $ExpectType number
+        expect(typeof narrowValue.toFixed).toBe('function')
+      } else {
+        // $ExpectType { foo: ()=>{} }
+        // @ts-ignore
+        expect(() => narrowValue.foo()).toThrow()
+      }
     })
   })
 

--- a/src/guards/type-guards.ts
+++ b/src/guards/type-guards.ts
@@ -8,7 +8,8 @@ export const isBoolean = (value: any): value is boolean =>
   typeof value === 'boolean'
 export const isString = (value: any): value is string =>
   typeof value === 'string'
-export const isNumber = (value: any) => typeof value === 'number'
+export const isNumber = (value: any): value is number =>
+  typeof value === 'number'
 export const isArray = <T>(value: any): value is Array<T> =>
   Array.isArray(value)
 export const isObject = <T extends object>(value: any): value is T =>


### PR DESCRIPTION
_If there is a linked issue, mention it here._

- [x] Bug
- [ ] Feature

## Requirements

- [x] Read the [contribution guidelines](./.github/CONTRIBUTING.md).
- [x] Wrote tests.
- [ ] Updated docs and upgrade instructions, if necessary.

## Rationale

`isNumber` was not a type guard rather then normal function