### PR TITLE
fix(type-guards): properly narrow isFunction guard to potentional fun…

### DIFF
--- a/src/__tests__/guards/type-guards.spec.ts
+++ b/src/__tests__/guards/type-guards.spec.ts
@@ -38,14 +38,17 @@ describe(`type guards`, () => {
         // $ExpectType number[]
         expect(arrWithTypes[0].toString()).toBe('1')
       } else {
-        arrWithTypes.toString()
+        // $ExpectType string
+        expect(typeof arrWithTypes).toBe('string')
       }
 
       if (isArray(arrWithComplexTypes)) {
         // $ExpectType Array<{ who: string }>
         expect(arrWithComplexTypes[0].who).toBe('Me')
       } else {
-        arrWithTypes.toString()
+        // $ExpectType string
+        // @ts-ignore
+        expect(arrWithComplexTypes[0].who).toThrow()
       }
     })
   })
@@ -91,15 +94,26 @@ describe(`type guards`, () => {
       expect(isFunction(noop)).toBe(true)
 
       type FnDefinition = (count: number, who: string) => string
-      const fnImplementation: FnDefinition | any[] = ((
+
+      const fnImplementation: FnDefinition | any[] = (
         count: number,
         who: string
-      ) => `${who}: ${count} times`) as any
+      ) => {
+        if (!isNumber(count) || !isString(who)) {
+          throw new Error(`arguments doesn't match allowed types`)
+        }
+
+        return `${who}: ${count} times`
+      }
 
       if (isFunction(fnImplementation)) {
         // $ExpectType (count: number, who: string) => `${who}: ${count} times`
         expect(typeof fnImplementation).toBe('function')
         expect(fnImplementation(3, 'Me')).toBe('Me: 3 times')
+        // @ts-ignore
+        expect(() => fnImplementation(true, 123)).toThrowError(
+          `arguments doesn't match allowed types`
+        )
       } else {
         // @ts-ignore
         expect(() => fnImplementation(3, 'Me')).toThrow()

--- a/src/guards/type-guards.ts
+++ b/src/guards/type-guards.ts
@@ -1,8 +1,9 @@
-import { AnyFunction, Nullable } from '../types'
+import { Nullable } from '../types'
 
 export const isBlank = <T>(value: T): value is Nullable<T> => value == null
 export const isPresent = <T>(value: T): value is NonNullable<T> => value != null
-export const isFunction = <T extends AnyFunction>(value: any): value is T =>
+// tslint:disable-next-line:ban-types
+export const isFunction = (value: any): value is Function =>
   typeof value === 'function'
 export const isBoolean = (value: any): value is boolean =>
   typeof value === 'boolean'


### PR DESCRIPTION
…ction type

_If there is a linked issue, mention it here._

- [x] Bug
- [ ] Feature

## Requirements

- [x] Read the [contribution guidelines](./.github/CONTRIBUTING.md).
- [x] Wrote tests.
- [ ] Updated docs and upgrade instructions, if necessary.

## Rationale

isFunction narrowed checked type to `AnyFunction` which looses all argument types