### PR TITLE
feat(type-guards): better isEmpty

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,9 +147,10 @@ rex-tils API is tiny and consist of 2 categories:
 
 - checks if value is not null nor undefined
 
-**`isEmpty<T extends string | object | any[]>(value:T): T`**
+**`isEmpty<T extends string | object>(value:T): Empty<T>`**
 
-- checks if value is empty for string | array | object otherwise it throws an error
+- checks if value is empty for string | array | object otherwise it throws an error.
+- also it narrows the type to empty type equivalent
 
 **`isFunction(value:any)`**
 

--- a/src/__tests__/guards/type-guards.spec.ts
+++ b/src/__tests__/guards/type-guards.spec.ts
@@ -11,6 +11,7 @@ import {
   isPromise,
   isString,
 } from '../../guards'
+import { Empty } from '../../guards/types'
 
 // tslint:disable:no-magic-numbers
 
@@ -261,7 +262,7 @@ describe(`type guards`, () => {
       expect(isEmpty(str)).toBe(false)
 
       if (isEmpty(str)) {
-        // $ExpectType never
+        // $ExpectType ''
         expect(str[1].toUpperCase()).toThrow()
       } else {
         // $ExpectType 'hello'
@@ -275,7 +276,7 @@ describe(`type guards`, () => {
       expect(isEmpty(emptyArr)).toBe(true)
 
       if (isEmpty(arr)) {
-        // $ExpectType never
+        // $ExpectType never[]
         expect(arr[1]).toThrow()
       } else {
         // $ExpectType string[]
@@ -288,13 +289,15 @@ describe(`type guards`, () => {
     })
 
     it(`should return true for empty objects`, () => {
-      const obj = { one: 1, two: 2 }
+      const obj = { one: 1, two: 2 } as
+        | { one: number; two: number }
+        | Empty.Object
 
       expect(isEmpty(emptyObj)).toBe(true)
       expect(isEmpty(obj)).toBe(false)
 
       if (isEmpty(obj)) {
-        // $ExpectType never
+        // $ExpectType Record<string,never>
         // @ts-ignore
         expect(obj.one.toString()).toThrow()
       } else {

--- a/src/guards/type-guards.ts
+++ b/src/guards/type-guards.ts
@@ -1,4 +1,5 @@
 import { Nullable } from '../types'
+import { Bottom, Empty } from './types'
 
 export const isBlank = <T>(value: T): value is Nullable<T> => value == null
 export const isPresent = <T>(value: T): value is NonNullable<T> => value != null
@@ -48,9 +49,9 @@ export const isPromise = (value: any): value is PromiseLike<any> =>
  * Checks if string OR array OR object are empty
  * If you provide another value to check it will throw an error
  */
-export const isEmpty = <T extends string | object | any[]>(
-  value: T
-): value is never => {
+export const isEmpty = <T extends string | object>(
+  value: T | Empty
+): value is Bottom<T> => {
   if (isString(value) || isArray(value)) {
     return value.length === 0
   }

--- a/src/guards/types.ts
+++ b/src/guards/types.ts
@@ -22,8 +22,12 @@ export interface NonEmptyArray<T> extends Array<T> {
 
 // https://twitter.com/karoljmajewski/status/1037618989801893888?s=20
 export type Empty = Empty.Array | Empty.Object | Empty.String
-declare namespace Empty {
+export declare namespace Empty {
   type String = ''
   type Array = never[]
   type Object = Record<string, never>
 }
+
+export type Bottom<T> = T extends string
+  ? Empty.String
+  : T extends any[] ? Empty.Array : T extends object ? Empty.Object : never


### PR DESCRIPTION
- properly constraints to Bottom value when isEmpty matches instead of casting to never

_If there is a linked issue, mention it here._

- [ ] Bug
- [x] Feature

## Requirements

- [x] Read the [contribution guidelines](./.github/CONTRIBUTING.md).
- [x] Wrote tests.
- [x] Updated docs and upgrade instructions, if necessary.

## Rationale

Tweak `isEmpty` guard after discussion on SO and twitter
https://stackoverflow.com/a/52202691/3819491