### PR TITLE
feat(type-guards): improve isObject type narrowing and implement new …

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,15 +162,16 @@ rex-tils API is tiny and consist of 2 categories:
 
 **`isArray(value:any)`**
 
-**`isObject<T extends object>(value:any): T`**
+**`isObject<T>(value:T): T`**
 
-- to get proper type object within if branch, you need to explicitly provide generic value otherwise it will be narrowed to `object` only
+- normalized check if JS value is an object. That means anything that is not an array, not null/undefined but typeof value equals to 'object'
+- it will also properly narrow type within the branch
 
 ```ts
 type MyMap = { who: string; age: number }
-declare const someObj: object | string | number
+declare const someObj: MyMap | string | number
 
-if (isObject<MyMap>(someObj)) {
+if (isObject(someObj)) {
   // $ExpectType MyMap
   someObj
 } else {
@@ -379,6 +380,14 @@ const obj: Result = {
   three: false,
 }
 ```
+
+**`Primitive<T>`**
+
+- narrows type to primitive JS value ( boolean, string, number, symbol )
+
+**`NonPrimitive<T>`**
+
+- narrows type to non-primitive JS value ( object, function, array )
 
 **`Nullable<T>`**
 

--- a/src/__tests__/guards/type-guards.spec.ts
+++ b/src/__tests__/guards/type-guards.spec.ts
@@ -55,13 +55,13 @@ describe(`type guards`, () => {
   })
 
   describe(`isObject`, () => {
-    it(`should return false if value is not an object map`, () => {
-      type MyMap = { who: string; age: number }
-      const possibleValidObj = {
-        who: 'John',
-        age: 32,
-      } as MyMap | string | boolean
+    type MyMap = { who: string; age: number }
+    const possibleValidObj = {
+      who: 'John',
+      age: 32,
+    } as MyMap | string | boolean
 
+    it(`should return false if value is not an object map`, () => {
       expect(isObject(123)).toBe(false)
       expect(isObject('hello')).toBe(false)
       expect(isObject(null)).toBe(false)
@@ -69,10 +69,11 @@ describe(`type guards`, () => {
       expect(isObject(true)).toBe(false)
       expect(isObject(noop)).toBe(false)
       expect(isObject(emptyArr)).toBe(false)
-
       expect(isObject(emptyObj)).toBe(true)
+    })
 
-      if (isObject<MyMap>(possibleValidObj)) {
+    it(`should properly type constraint object via inference`, () => {
+      if (isObject(possibleValidObj)) {
         // $ExpectType {one:number}
         expect(possibleValidObj).toHaveProperty('age')
         const { age } = possibleValidObj
@@ -83,6 +84,22 @@ describe(`type guards`, () => {
         // @ts-ignore
         const { one } = possibleValidObj
         expect(one).toThrow()
+      }
+    })
+
+    it(`should properly type constraint object with array exclusion via inference`, () => {
+      const arr = [1, 2, 3] as number[] | { one: 1 }
+      if (isObject(arr)) {
+        // $ExpectType { one: 1 }
+        expect(arr).toThrow()
+        // @ts-ignore
+        const [first] = arr
+        expect(first).toThrow()
+      } else {
+        // $ExpectType number[]
+        expect(arr).toHaveProperty('length')
+        const [first] = arr
+        expect(first).toBe(1)
       }
     })
   })

--- a/src/__tests__/types.spec.ts
+++ b/src/__tests__/types.spec.ts
@@ -3,10 +3,12 @@ import {
   Brand,
   Keys,
   KnownKeys,
+  NonPrimitive,
   Omit,
   OptionalKnownKeys,
   PickWithType,
   PickWithTypeUnion,
+  Primitive,
   RequiredKnownKeys,
   UnionFromTuple,
 } from '../types'
@@ -215,6 +217,36 @@ describe(`generic TS type utils`, () => {
         street: null,
       }
       expect(nullableValues).toBeTruthy()
+    })
+  })
+
+  describe('standard lib mapped types extensions', () => {
+    it(`should correctly narrow primitive types via Primitive<T>`, () => {
+      type Test = boolean | number | [1, 2, 4] | string[] | { one: number }
+
+      // $ExpectType boolean | number
+      type Expected = Primitive<Test>
+
+      const actual: Test = { one: 111 }
+      // $ExpectError
+      // @ts-ignore
+      const expected: Expected = { one: 111 }
+
+      expect(actual).toEqual(expected)
+    })
+
+    it(`should correctly narrow non-primitive types via NonPrimitive<T>`, () => {
+      type Test = boolean | number | [1, 2, 4] | string[] | { one: number }
+
+      // $ExpectType [1, 2, 4] | string[] | { one: number; }
+      type Expected = NonPrimitive<Test>
+
+      const actual: Test = 2222
+      // $ExpectError
+      // @ts-ignore
+      const expected: Expected = 2222
+
+      expect(actual).toBe(expected)
     })
   })
 })

--- a/src/guards/type-guards.ts
+++ b/src/guards/type-guards.ts
@@ -1,5 +1,5 @@
-import { Nullable } from '../types'
-import { Bottom, Empty } from './types'
+import { Maybe, NonPrimitive, Nullable } from '../types'
+import { Bottom, Empty, NonArray } from './types'
 
 export const isBlank = <T>(value: T): value is Nullable<T> => value == null
 export const isPresent = <T>(value: T): value is NonNullable<T> => value != null
@@ -22,9 +22,9 @@ export const isArray = <T>(value: any): value is Array<T> =>
  * @example
  * ```ts
  * type MyMap = { who: string; age: number }
- * declare const someObj: object | string | number
+ * declare const someObj: MyMap | string | number
  *
- * if (isObject<MyMap>(someObj)) {
+ * if (isObject(someObj)) {
  *  // $ExpectType MyMap
  *  someObj
  * } else {
@@ -33,7 +33,9 @@ export const isArray = <T>(value: any): value is Array<T> =>
  * }
  * ```
  */
-export const isObject = <T extends object>(value: any): value is T =>
+export const isObject = <T extends Maybe<{}>>(
+  value: T
+): value is NonArray<NonPrimitive<NonNullable<T>>> =>
   value != null && !Array.isArray(value) && typeof value === 'object'
 
 export const isDate = (value: any): value is Date =>

--- a/src/guards/types.ts
+++ b/src/guards/types.ts
@@ -1,6 +1,11 @@
 type Blank = null | undefined | void
 
 /**
+ * @private
+ */
+export type NonArray<T> = T extends any[] ? never : T
+
+/**
  * // object collects {} and Array<any> so adding both {} and Array<any> is not needed
  * @private
  */

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,9 @@ export type Omit<T, K> = Pick<T, Exclude<keyof T, keyof K>>
  */
 export type Nullable<T> = T extends null | undefined ? T : never
 
+export type Primitive<T> = T extends object ? never : T
+export type NonPrimitive<T> = T extends object ? T : never
+
 /**
  * Maybe types accept the provided type as well as null or undefined
  */


### PR DESCRIPTION
…mapped types

BREAKING CHANGE: 
consumers of isObject which used previously explicitly type generic for constraint
may experience compile errors because now `isObject` does type narrowing properly without any imperative need to define generic on function call. To fix this just remove those explicit generic types on object as `isObject` will now work correctly as expected:

**Before:**

```ts
const possibleObj: SomeModel | string = getData()

if(isObject<SomeModel>(possibleObj)){
  // possibleObj is SomeModel
}
```

**After:**

```ts
const possibleObj: SomeModel | string = getData()

if(isObject(possibleObj)){
  // possibleObj is SomeModel
}
```

_If there is a linked issue, mention it here._

- [ ] Bug
- [x] Feature

## Requirements

- [x] Read the [contribution guidelines](./.github/CONTRIBUTING.md).
- [x] Wrote tests.
- [x] Updated docs and upgrade instructions, if necessary.