### PR TITLE
fix(action.ts): do not freeze actions in dev mode

### DIFF
--- a/src/__tests__/redux/actions.spec.ts
+++ b/src/__tests__/redux/actions.spec.ts
@@ -5,17 +5,6 @@ import { ActionsOfType, ActionsUnion, createAction } from '../../redux'
 // tslint:disable:no-magic-numbers
 
 describe(`Redux type-safe action helpers`, () => {
-  describe(`Should create immutable objects`, () => {
-    const SET_AGE = '[core] set age'
-    const setAge = (age: number) => createAction(SET_AGE, age)
-    const setAgeAction = setAge(33)
-
-    // @ts-ignore
-    expect(() => (setAgeAction.type = 'Foo')).toThrow()
-    // @ts-ignore
-    expect(() => (setAgeAction.payload = 44)).toThrow()
-  })
-
   describe(`Should be able to extract action type from Union`, () => {
     enum ActionTypes {
       SET_AGE = '[core] set age',

--- a/src/__tests__/redux/actions.spec.ts
+++ b/src/__tests__/redux/actions.spec.ts
@@ -5,6 +5,17 @@ import { ActionsOfType, ActionsUnion, createAction } from '../../redux'
 // tslint:disable:no-magic-numbers
 
 describe(`Redux type-safe action helpers`, () => {
+  describe(`Should create compile time only immutable objects`, () => {
+    const SET_AGE = '[core] set age'
+    const setAge = (age: number) => createAction(SET_AGE, age)
+    const setAgeAction = setAge(33)
+
+    // @ts-ignore
+    expect(() => (setAgeAction.type = 'Foo')).not.toThrow()
+    // @ts-ignore
+    expect(() => (setAgeAction.payload = 44)).not.toThrow()
+  })
+
   describe(`Should be able to extract action type from Union`, () => {
     enum ActionTypes {
       SET_AGE = '[core] set age',

--- a/src/redux/actions.ts
+++ b/src/redux/actions.ts
@@ -1,4 +1,3 @@
-import { IS_DEV } from '../environment'
 import { Action } from './types'
 
 export function createAction<T extends string>(type: T): Action<T>
@@ -9,5 +8,5 @@ export function createAction<T extends string, P>(
 export function createAction<T extends string, P>(type: T, payload?: P) {
   const action = payload === undefined ? { type } : { type, payload }
 
-  return IS_DEV ? Object.freeze(action) : action
+  return action
 }


### PR DESCRIPTION
fix #21

_If there is a linked issue, mention it here._

- [X] Bug
- [ ] Feature

## Requirements

- [X] Read the [contribution guidelines](./.github/CONTRIBUTING.md).
- [X] Wrote tests.
- [X] Updated docs and upgrade instructions, if necessary.

## Rationale

_Why is this PR necessary?_
Allows usage of the library with redux-saga or any other library that updates the action objects.

## Implementation
Removed Object.freeze in action.ts
_Why have you implemented it this way? Did you try any other methods?_

## Open questions

_Are there any open questions about this implementation that need answers?_

## Other
On my box I was not able to run all the tests, even in master branch. I get lot of build errors. But I belive these changes are enough to work, I will monitor the PR build to see if there are any issues.
 All the errors are in as follows
" src/__tests__/redux/rx-operators.spec.ts:3:24 - error TS1149: File name 'E:/rex-tils/src/redux/rx-operators.ts' differs from already included file name 'e:/rex-tils/src/redux/rx-operators.ts' only in casing."
