### PR TITLE
docs: use angle bracket syntax for enum type def

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ As described in [10 TypeScript Pro tips article](https://medium.com/@martin_hote
 // $ExpectType Readonly<{ No: "No"; Yes: "Yes"; }>
  export const AnswerResponse = Enum('No', 'Yes')
  // $ExpectType 'No' | 'Yes'
- export type AnswerResponse = Enum(typeof AnswerResponse)
+ export type AnswerResponse = Enum<typeof AnswerResponse>
 
  // consumer.ts
 


### PR DESCRIPTION
Howdy! I _think_ I found a small typo in the docs re: exporting enum types. Let me know if I'm off base.

When exporting an `Enum` type, it's necessary to use the angle brackets (instead of parentheses).
```
 export const AnswerResponse = Enum('No', 'Yes')
 export type AnswerResponse = Enum<typeof AnswerResponse>
// ^^ if we use parentheses again here, we'll get a Typescript compilation error.
```
_If there is a linked issue, mention it here._

## Requirements

- [x] Read the [contribution guidelines](./.github/CONTRIBUTING.md).
- [x] Updated docs and upgrade instructions, if necessary.

## Rationale

_Why is this PR necessary?_

The docs aren't accurate and might confuse people (like me).
